### PR TITLE
Callback never gets called

### DIFF
--- a/lib/qrcode.js
+++ b/lib/qrcode.js
@@ -46,7 +46,6 @@ qrcode.decode = function(src, callback){
 
     if(src == null)
     {
-        callback = src;
         var canvas_qr = document.getElementById("qr-canvas");
         var context = canvas_qr.getContext('2d');
         qrcode.width = canvas_qr.width;


### PR DESCRIPTION
If src is null as conditioned then callback becomes null, too. Removed the line where null gets assigned to callback.
